### PR TITLE
[#2] 텍스트 콘텐츠를 위한 페르소나 추출 노드 추가

### DIFF
--- a/agents/text/modules/chains.py
+++ b/agents/text/modules/chains.py
@@ -9,6 +9,7 @@ from langchain.schema.runnable import RunnablePassthrough, RunnableSerializable
 from langchain_core.output_parsers import StrOutputParser
 
 from agents.text.modules.models import get_openai_model
+from agents.text.modules.persona import PERSONA
 from agents.text.modules.prompts import get_extraction_prompt
 
 
@@ -40,6 +41,7 @@ def set_extraction_chain() -> RunnableSerializable:
         RunnablePassthrough.assign(
             content_topic=lambda x: x["content_topic"],  # 콘텐츠 주제 추출
             content_type=lambda x: x["content_type"],  # 콘텐츠 유형 추출
+            persona_details=lambda x: PERSONA,
         )
         | prompt  # 프롬프트 적용
         | model  # LLM 모델 호출

--- a/agents/text/modules/nodes.py
+++ b/agents/text/modules/nodes.py
@@ -33,5 +33,7 @@ class PersonaExtractionNode(BaseNode):
             }
         )
 
+        state["persona_extracted"] = extracted_persona
+
         # 추출된 페르소나를 응답으로 반환
         return {"response": extracted_persona}

--- a/agents/text/modules/state.py
+++ b/agents/text/modules/state.py
@@ -18,6 +18,7 @@ class TextState(TypedDict):
     content_topic: str  # 콘텐츠의 주제 (예: "여름 휴가", "음식 리뷰")
     content_type: str  # 콘텐츠의 유형 (예: "블로그 글", "소셜 미디어 포스트")
     query: str  # 사용자 쿼리 또는 요청사항
+    persona_extracted: str  # 추출된 페르소나 전문
     response: Annotated[
         list, add_messages
     ]  # 응답 메시지 목록 (add_messages로 주석되어 메시지 추가 기능 제공)


### PR DESCRIPTION
## 📝 Summary

<!--
PR의 주요 내용을 간단히 요약해주세요.
예: 로그인 기능에서 사용자 세션 관리 개선.
-->

텍스트 콘텐츠를 위한 페르소나 요약문 생성 노드를 추가합니다.

## ✅ Checklist

<!--
해당되는 항목을 [x]로 만들어주세요.
예: - [x] 관련 이슈가 명시되어 있습니다.

해당되지 않는 항목은 앞뒤로 ~를 붙여서 취소선을 그어주세요.
예: - ~[ ] 관련 이슈가 명시되어 있습니다.~
-->

- [x] 관련 이슈가 명시되어 있습니다.
- [x] 테스트가 완료되었습니다.
- ~[ ] 문서 업데이트가 포함되었습니다.~
- [x] 코드 리뷰를 위한 사전 검토를 완료했습니다.

## 📄 Description

<!--
PR의 변경 사항을 구체적으로 설명해주세요.
예: 이번 변경 사항에는 로그인 세션 시간 연장 및 오류 메시지 개선이 포함됩니다.
-->

- `agents/text/modules/prompt.py`에 페르소나 전문이 저장됩니다.
- `agents/text/modules/state.py`에 페르소나 요약문 attribute를 추가합니다.
- 해당 노드에 페르소나 요약문을 출력하고, `TextState`에 저장하도록 변경합니다.

## 💡 Notice (Optional)

<!--
리뷰어가 알아야 할 추가적인 사항이나 주의점이 있다면 작성해주세요.
예: 이 기능은 인증 모듈과 호환성을 고려해야 합니다.
-->

## 🔗 Related Issue(s)

<!--
이 PR과 관련된 이슈나 기존 PR이 있다면 번호를 언급하고, 필요 시 close할 이슈도 명시해주세요.
예: 관련 이슈 - #33, close #27
-->

close #2 
